### PR TITLE
using dperf to test bandwidth on ARM and x86 server

### DIFF
--- a/test/performance/bandwidth/README.md
+++ b/test/performance/bandwidth/README.md
@@ -1,0 +1,94 @@
+# Using dperf to test network bandwidth
+## Introduction
+
+DPDK(https://github.com/DPDK/dpdk) is a set of libraries and drivers for fast packet processing.
+It supports many processor architectures and both FreeBSD and Linux.
+
+dperf(https://github.com/baidu/dperf) is a DPDK based 100Gbps network performance and load testing software.
+
+*Maybe dpdk-ans/f-stack/flexTOE are all open source high performant network frameworks based on DPDK and can be used to bw test, but they are not used by us because they do not support arm or the supported dpdk version is too old.*
+
+**Practice has proved that dperf can support the latest dpdk version, and support cx5/cx6 NIC, and can be compiled and run successfully on ARM.**
+
+## Compile DPDK
+
+1. install rdma-core driver
+
+    (1) git clone https://github.com/linux-rdma/rdma-core
+
+    (2) cd rdma-core/
+
+    (3) bash build.sh
+
+    (4) export RDMA_CORE_BUILD_DIR=/root/rdma-core/build
+
+    (5) export C_INCLUDE_PATH=$RDMA_CORE_BUILD_DIR/include
+
+    (6) export LIBRARY_PATH=$RDMA_CORE_BUILD_DIR/lib
+
+    (7) export LD_LIBRARY_PATH=$RDMA_CORE_BUILD_DIR/lib
+
+
+2. apt install doca-tools
+    
+    note: This step is necessary, otherwise the dpdk version after v20(v19.11 not require it) will occur "rxp_compile.h not found".). 
+    You can run "rxpbench" to check whether the installation is successful. If there are dependency errors in apt installation, we recommend using aptitude.
+
+
+3. git clone https://github.com/DPDK/dpdk(version:22.07-rc2)(v22.03,v21.11,v20.11 are all ok).
+
+4. meason build
+
+5. cd build
+
+6. ninja -j [THREADS NUM]
+("export LD_LIBRARY_PATH=/usr/lib/aarch64-linux-gnu/:$LD_LIBRARY_PATH"/"export LD_LIBRARY_PATH=/usr/local/lib/aarch64-linux-gnu/:$LD_LIBRARY_PATH"/"export LD_LIBRARY_PATH=/root/rdma-core/build/lib/:$LD_LIBRARY_PATH" may be useful)
+
+7. ninja install
+
+8. config hugepage: "echo 4096 > /sys/devices/system/node/node0/hugepages/hugepages-2048kB/nr_hugepages"
+
+    Only the configuration of 2M page is shown here, and the rest is for reference http://doc.dpdk.org/spp/setup/getting_started.html.
+
+9. run helloworld
+
+    (1) cd /root/dpdk/examples/helloworld
+
+    (2) make
+
+    (3) ./build/helloworld("Probe PCI driver" and "hello from core" will be shown.)
+
+## Compile dperf
+
+1. git clone https://github.com/baidu/dperf/
+
+2. cd dperf/
+
+3. export PKG_CONFIG_PATH=/usr/local/lib/aarch64-linux-gnu/pkgconfig
+
+4. make
+
+5. run "./build/dperf" to check whether the installation is successful
+
+## Configuration for bw test
+
+1. Specific configuration information reference https://github.com/baidu/dperf/blob/main/docs/configuration.md
+
+2. System setup
+
+    (1) Client and server are connected through 100Gb bluefield-2 integrated connectx-6.
+
+    (2) "nic_setip.sh" will help you to setup a series of ip addresses quickly.(bash nic_setip.sh [START IP] [the NUMBERS of IP ADDRESSES] [INTERFACE])
+
+    (3) The NIC in client side is configured with an IP address within the range of 192.168.31.50-192.168.31.57.
+
+    (4) The NIC in server side is configured with an IP address within the range of 192.168.31.200-192.168.31.207.
+
+3. The configuration file for running dperf with 8 CPUs is placed "dperf-config".
+    
+    (1) Modify the number of CPU cores used by dperf by modifying the "CPU" and "server" configuration items.
+
+    (2) Increasing "cc" gradually may help you improve bandwidth.
+
+    (3) "dperf-config/client-template-bw.conf" and "dperf-config/server-template-bw.conf" provide templates for testing bandwidth.
+

--- a/test/performance/bandwidth/dperf-config/client-template-bw.conf
+++ b/test/performance/bandwidth/dperf-config/client-template-bw.conf
@@ -1,0 +1,17 @@
+mode                        client
+tx_burst                    1024
+launch_num                  3
+# Example: cpu 0 1 2 3 4 5, must be equal to [Server IPAddrNumber]
+cpu                         [n0] [n1] [n2] [...]
+payload_size                1400
+duration                    120s
+cps                         500
+# Gradually increase until the maximum bandwidth is reached
+# Example: cc 30000
+cc                          [Concurrent Connections]
+keepalive                   1ms
+port        0000:03:00.1    192.168.31.200   192.168.31.50 08:c0:eb:d1:f7:8f
+# Configure a series of IP addresses(may be nic_setip.sh is useful)
+client      192.168.31.200      [Client IPAddrNumber]
+server      192.168.31.50     [Server IPAddrNumber]
+listen 80 1

--- a/test/performance/bandwidth/dperf-config/client.conf
+++ b/test/performance/bandwidth/dperf-config/client.conf
@@ -1,0 +1,13 @@
+mode                        client
+tx_burst                    1024
+launch_num                  3
+cpu                         0 1 2 3 4 5 6 7
+payload_size                1400
+duration                    120s
+cps                         500
+cc                          30000
+keepalive                   1ms
+port        0000:03:00.1    192.168.31.200   192.168.31.50 08:c0:eb:d1:f7:8f
+client      192.168.31.200      8
+server      192.168.31.50     8
+listen 80 1

--- a/test/performance/bandwidth/dperf-config/server-template-bw.conf
+++ b/test/performance/bandwidth/dperf-config/server-template-bw.conf
@@ -1,0 +1,12 @@
+mode                        server
+tx_burst                    1024
+# Example: cpu 0 1 2 3 4 5, must be equal to [Server IPAddrNumber]
+cpu                         [n0] [n1] [n2] [...]
+duration                    150s
+payload_size                1400
+keepalive                   1s
+port                        0000:03:00.1    192.168.31.50   192.168.31.200
+# Configure a series of IP addresses(may be nic_setip.sh is useful)
+client      192.168.31.200      [Client IPAddrNumber]
+server      192.168.31.50     [Server IPAddrNumber]
+listen 80 1

--- a/test/performance/bandwidth/dperf-config/server.conf
+++ b/test/performance/bandwidth/dperf-config/server.conf
@@ -1,0 +1,10 @@
+mode                        server
+tx_burst                    1024
+cpu                         0 1 2 3 4 5 6 7
+duration                    150s
+payload_size                1400
+keepalive                   1s
+port                        0000:03:00.1    192.168.31.50   192.168.31.200
+client      192.168.31.200      8
+server      192.168.31.50     8
+listen 80 1

--- a/test/performance/bandwidth/nic_setip.sh
+++ b/test/performance/bandwidth/nic_setip.sh
@@ -1,0 +1,11 @@
+start=$1
+num=$2
+interface=$3
+declare -i i=1
+while ((i<=8))
+do
+    let j=start+i
+    echo 192.168.31.$j
+    ip addr add 192.168.31.$j/24 dev $interface
+    let i=i+1
+done


### PR DESCRIPTION
1.Compile dperf/dpdk on arm/x86 servers with 100GB cx5/cx6 network cards.
2.Guide and configuration for bandwidth test with dperf.