### PR TITLE
fix: resolve compilation errors

### DIFF
--- a/src/dpdk.c
+++ b/src/dpdk.c
@@ -30,6 +30,9 @@
 #include <rte_mbuf.h>
 #include <rte_compat.h>
 #include <rte_pdump.h>
+#if RTE_VERSION >= RTE_VERSION_NUM(20, 0, 0, 0)
+#include <rte_vect.h>
+#endif
 
 #include "mbuf.h"
 #include "flow.h"


### PR DESCRIPTION
In the ARM environment, compiling dperf with a DPDK version of RTE_VERSION_NUM(20, 0, 0, 0) or higher results in an error. The reason is that the header file rte_vect.h is not included in the ARM environment. It makes sense to explicitly include this header file, regardless of whether it is in ARM or x86, so include it when the DPDK version is >= RTE_VERSION_NUM (20, 0, 0, 0).