### PR TITLE
fix: work_space leaks memory and mbuf TLS pool on exit

### DIFF
--- a/src/work_space.c
+++ b/src/work_space.c
@@ -190,6 +190,7 @@ static struct work_space *work_space_alloc(struct config *cfg, int id)
             ws = (struct work_space *)p;
             memset(p, 0, size);
             ws->mmap = 1;
+            ws->mmap_size = size;
         }
     }
     if (ws != NULL) {
@@ -278,7 +279,16 @@ err:
 
 void work_space_close(struct work_space *ws)
 {
+    if (ws == NULL) {
+        return;
+    }
     work_space_close_log(ws);
+    mbuf_free2_flush();
+    if (ws->mmap) {
+        munmap(ws, ws->mmap_size);
+    } else {
+        rte_free(ws);
+    }
 }
 
 bool work_space_ip_exist(const struct work_space *ws, uint32_t ip)

--- a/src/work_space.h
+++ b/src/work_space.h
@@ -77,6 +77,7 @@ struct work_space {
 
     /* bytes */
     uint32_t send_window;
+    size_t mmap_size;
 
     uint8_t tos;
     uint8_t port_id;


### PR DESCRIPTION
work_space_alloc may use mmap(MAP_HUGE_1GB) for GB-scale blocks or rte_calloc for smaller ones, but work_space_close only closed the log file, never releasing the work_space itself. ws->mmap was set but never read, so the mmap branch silently leaked huge pages on every worker lcore exit. The mmap length was also not stored, making a future munmap call impossible without it.

Save the mmap size in ws->mmap_size. work_space_close now branches on ws->mmap: munmap() for the mmap path, rte_free() for the rte_calloc path. Add a NULL guard so the function is safe to call on a NULL work_space.

Also call mbuf_free2_flush() from work_space_close so each lcore drains its per-thread mbuf free pool on exit. Otherwise up to 127 mbufs per worker thread stay pinned in the TLS pool and never return to the mempool.