### PR TITLE
fix: use ntohl on th_seq in tcp_client_process_syn_ack

### DIFF
--- a/src/tcp.c
+++ b/src/tcp.c
@@ -461,7 +461,7 @@ static inline void tcp_client_process_syn_ack(struct work_space *ws, struct sock
     struct rte_mbuf *m, struct tcphdr *th)
 {
     uint32_t ack = ntohl(th->th_ack);
-    uint32_t seq = htonl(th->th_seq);
+    uint32_t seq = ntohl(th->th_seq);
 
     if (sk->state == SK_SYN_SENT) {
         if (ack != sk->snd_nxt) {


### PR DESCRIPTION
th->th_seq arrives in network byte order. 
Reading it into a host-side variable (later stored in sk->rcv_nxt) must use ntohl, not htonl. 
htonl has the same bit pattern as ntohl on little-endian hosts so the bug is invisible on x86, 
but it expresses the wrong intent and will mis-seed rcv_nxt on any big-endian target.

Aligns with tcp_server_process_ack a few lines below, which already uses ntohl on the same field.