### PR TITLE
fix: csum_pseudo_ipv4 was missing final one's complement

### DIFF
--- a/src/csum.c
+++ b/src/csum.c
@@ -39,7 +39,7 @@ static inline uint16_t csum_pseudo_ipv4(uint8_t proto, uint32_t sip, uint32_t di
     csum = (csum & 0x0000ffffUL) + (csum >> 16);
     csum = (csum & 0x0000ffffUL) + (csum >> 16);
 
-    return (uint16_t)csum;
+    return (uint16_t)~csum;
 }
 
 static inline uint16_t csum_pseudo_ipv6(uint8_t proto, struct in6_addr *saddr, struct in6_addr *daddr,


### PR DESCRIPTION
csum_pseudo_ipv4 builds the IPv4 pseudo-header sum for TCP/UDP checksums but returns the raw sum without the mandatory one's complement, so every caller received the arithmetic inverse of what a network receiver expects.

The bug is invisible on TX-checksum-offload paths because the NIC re-computes the checksum from scratch. On software paths the result is written straight to th->th_sum / uh->check (udp.c) or fed into csum_update_u32 (tcp.c), which assumes its ocsum argument is the final complemented value. Both paths therefore produced wrong checksums.

Return ~csum to match the 1's-complement standard and the behaviour of csum_pseudo_ipv6, which delegates to rte_raw_cksum and already returns a complemented value.