### PR TITLE
fix: guard rte_kni_release against NULL after rte_kni_alloc failure

### DIFF
--- a/src/kni.c
+++ b/src/kni.c
@@ -171,7 +171,9 @@ static struct rte_kni *kni_alloc(struct config *cfg, struct netif_port *port)
     kni = rte_kni_alloc(mbuf_pool, &conf, NULL);
 
     if (kni_set_hwaddr(cfg, port) < 0) {
-        rte_kni_release(kni);
+        if (kni) {
+            rte_kni_release(kni);
+        }
         return NULL;
     }
 


### PR DESCRIPTION
rte_kni_alloc can return NULL when the KNI kernel module is unloaded, hugepages are exhausted, or any other resource is unavailable. dperf then called rte_kni_release(kni) unconditionally in the hwaddr setup error path, dereferencing a NULL pointer and crashing the whole dperf process with no useful diagnostic.

Skip the release when the alloc failed, and let the function return NULL as it already does on the success path.