### PR TITLE
fix: http_parse CHUNK_DATA reads past end at chunk boundary

### DIFF
--- a/src/http_parse.c
+++ b/src/http_parse.c
@@ -198,6 +198,9 @@ retry:
 
             p += sk->http_length;
             sk->http_length = 0;
+            if (p >= end) {
+                return HTTP_PARSE_OK;
+            }
             c = *p;
             p++;
             if (c == '\r') {


### PR DESCRIPTION
Root cause:
  In HTTP_CHUNK_DATA, after skipping sk->http_length bytes of chunk
  data, p is dereferenced (*p) without checking that the resulting
  pointer is still within the buffer. When sk->http_length equals
  end - p - 1 (i.e. only one byte remains after the chunk data),
  p += sk->http_length advances p to exactly end, and the next
  *p dereference reads one byte past the valid buffer.

Impact:
  Triggered on every chunked HTTP response when the TCP segment
  boundary lands such that the last chunk-data byte and the
  trailing CRLF fall in different segments. The out-of-bounds
  byte may be '\r' (causing the parser to enter CHUNK_DATA_END
  and re-read) or another value (causing HTTP_PARSE_ERR on a
  otherwise valid chunked response). Can also leak the byte at
  end of the mbuf payload.

Style consistency:
  The function already uses the return HTTP_PARSE_OK on buffer
  exhaustion, resume on next call pattern in HTTP_CHUNK_DATA_END
  and HTTP_CHUNK_TRAILER_BEGIN. The new guard matches that exact
  pattern and does not alter the function external contract.