### PR TITLE
fix: csum_check_ipv4 overwrites UDP checksum with zero

### DIFF
--- a/src/csum.c
+++ b/src/csum.c
@@ -229,7 +229,7 @@ static int csum_check_ipv4(struct iphdr *iph)
             printf("csum udp error\n");
             return -1;
         }
-        uh->check = 0;
+        uh->check = csum_udp;
     }
     iph->check = csum_ip;
 


### PR DESCRIPTION
Root cause:
  In csum_check_ipv4, the UDP branch saves the original UDP
  checksum into the local variable csum_udp, zeroes uh->check
  for the RTE_IPV4_UDPTCP_CKSUM computation, and then sets
  uh->check back to 0 instead of the saved csum_udp. The TCP
  branch (line 224) and the IP branch (line 234) both restore
  the original field value; only the UDP branch was missing
  the restore, which is a clear copy-paste mistake.

Impact:
  csum_check_ipv4 is called in place on the mbuf, mutating the
  received packet header. The bug destroys the UDP checksum
  field in every received UDP packet that passes validation,
  and also corrupts the field before the early return -1 on
  validation failure. The destroyed value is observable to any
  downstream code that reads uh->check and breaks symmetry
  with the TCP and IP checksum restore paths in the same
  function.

Style consistency:
  After the fix, the IP, TCP, and UDP branches in
  csum_check_ipv4 follow the same save / clear / verify /
  restore pattern. No other call sites or files are affected.