### PR TITLE
fix: csum_check_ipv6 overwrites TCP checksum with zero

### DIFF
--- a/src/csum.c
+++ b/src/csum.c
@@ -252,6 +252,7 @@ static int csum_check_ipv6(struct ip6_hdr *ip6h)
             printf("csum tcp error\n");
             return -1;
         }
+        th->th_sum = csum_tcp;
     } else {
         csum_udp = uh->check;
         uh->check = 0;


### PR DESCRIPTION
Root cause:
  In csum_check_ipv6, the TCP branch saves the original TCP
  checksum into the local variable csum_tcp, zeroes th->th_sum
  for the RTE_IPV6_UDPTCP_CKSUM computation, and then never
  restores th->th_sum. The UDP branch in the same function
  (line 263) restores uh->check, and the TCP and UDP branches
  in the sibling csum_check_ipv4 also restore their fields.
  Only this branch was missing the restore.

Impact:
  csum_check_ipv6 mutates the received packet header in place
  on the mbuf. The bug zeroes the TCP checksum field on every
  received IPv6 TCP packet, on both the success and the
  early-return -1 failure path. The destroyed value breaks
  symmetry with the IPv4 path and with the IPv6 UDP path in
  the same function, and is observable to any downstream code
  reading th->th_sum.

Style consistency:
  After the fix, csum_check_ipv4 and csum_check_ipv6 both
  follow the save / clear / verify / restore pattern in every
  TCP and UDP branch. No other call sites or files affected.