### PR TITLE
fix: config_parse_tos silently accepts invalid input

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -1306,6 +1306,7 @@ static int config_parse_tos(int argc, char *argv[], void *data)
 
     if (config_parse_hex(argv[1], 0, 0xff, &tos) < 0) {
         printf("invalid tos %s\n", argv[1]);
+        return -1;
     }
 
     cfg->tos = tos;


### PR DESCRIPTION
Root cause:
  In config_parse_tos, when config_parse_hex fails the function
  only prints "invalid tos" and falls through to cfg->tos = tos
  with tos still equal to the initial 0, then returns 0 to
  signal success. Every other config_parse_* helper in the
  same file (e.g. config_parse_vxlan line 1217, config_parse_vlan
  line 1259, plus 13 other call sites) prints and returns -1 on
  invalid input; only this one was missing the return.

Impact:
  A user supplying an invalid TOS value, such as a non-numeric
  string or a value outside [0, 0xff], currently sees the error
  message but dperf continues to start with tos forced to 0
  while reporting a successful configuration. This is a silent
  failure that hides configuration mistakes and breaks the
  fail-fast contract that the other config_parse_* helpers
  implement. There is no uninitialized-read; tos is initialized
  to 0 on entry, so the field is set to 0 rather than garbage.

Style consistency:
  After the fix, config_parse_tos follows the same print-and-
  return -1 pattern used by the other 15 config_parse_* error
  sites in config.c. No other call sites or files affected.