### PR TITLE
fix: config_parse_cpu overwrites past cfg->cpu when cpu count exceeds 64

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -422,6 +422,7 @@ static int config_parse_cpu(int argc, char *argv[], void *data)
         for (cpu = cpu_min; cpu <= cpu_max; cpu++) {
             if (cpu_num + 1 > THREAD_NUM_MAX) {
                 printf("too much cpu %d > %d\n", cpu_num + 1, THREAD_NUM_MAX);
+                return -1;
             }
             cfg->cpu[cpu_num] = cpu;
             cpu_num++;


### PR DESCRIPTION
Root cause:
  In config_parse_cpu, the for loop that fills cfg->cpu checks
  `cpu_num + 1 > THREAD_NUM_MAX` and only prints a warning when
  the limit is reached, then continues to write cfg->cpu[cpu_num]
  and increments cpu_num. cfg->cpu is declared as
  `int cpu[THREAD_NUM_MAX]` (THREAD_NUM_MAX = 64), so the 65th
  iteration writes to cfg->cpu[64], the 66th to cfg->cpu[65],
  and so on, overflowing into the following cfg->cpu_num field
  and beyond.

Impact:
  Any cpu spec that resolves to 64 or more logical CPUs, for
  example `cpu 0-64` on a 128-CPU host, triggers an out-of-bounds
  write into struct config. The overrun corrupts the adjacent
  cfg->cpu_num field and, depending on struct layout, fields
  after it. The previous behavior also keeps dperf running with
  partially valid state, masking the configuration error from
  the user.

Style consistency:
  The fix returns -1 after printing the warning, matching the
  fail-fast pattern already used four times in the same function
  (lines 411, 419, 436) and across the rest of config_parse_* in
  this file. No other call sites or files are affected.