### PR TITLE
fix: port_init_mbuf_pool leaks mempools on partial failure

### DIFF
--- a/src/port.c
+++ b/src/port.c
@@ -81,12 +81,20 @@ static int port_init_mbuf_pool(struct netif_port *port)
     for (i = 0; i < port->queue_num; i++) {
         mbuf_pool = mbuf_pool_create("mp", port->id, i);
         if (mbuf_pool == NULL) {
-            return -1;
+            goto err;
         }
         port->mbuf_pool[i] = mbuf_pool;
     }
 
     return 0;
+
+err:
+    while (i > 0) {
+        i--;
+        rte_mempool_free(port->mbuf_pool[i]);
+        port->mbuf_pool[i] = NULL;
+    }
+    return -1;
 }
 
 static int port_config_vlan(struct rte_eth_conf *conf, struct rte_eth_dev_info *dev_info)


### PR DESCRIPTION
Root cause:
  port_init_mbuf_pool creates one rte_mempool per queue and
  stores each into port->mbuf_pool[i]. On a create failure at
  iteration k, the function returns -1 immediately, leaving
  the k mempools already created at index 0..k-1 reachable
  only through port. They are never freed, leaking them
  permanently for the lifetime of the process.

Impact:
  Triggered when mbuf_pool_create fails partway through, for
  example on a memory allocation failure or a too-large pool
  size. On a 64-queue port, the first failure could leave up
  to 63 mempools (each with NB_MBUF entries) leaked. The
  leaked mempools survive the function's -1 return and are
  never reachable through any other code path.

Style consistency:
  The fix uses a go-to-cleanup pattern that walks back the
  already-initialized indices and calls rte_mempool_free on
  each before returning -1. The pattern matches the standard
  DPDK and Linux kernel error handling used elsewhere in the
  codebase. No other call sites or files are affected.