### PR TITLE
fix: kni_create leaks kni and rte_ring on partial failure

### DIFF
--- a/src/kni.c
+++ b/src/kni.c
@@ -270,12 +270,16 @@ static int kni_create(struct config *cfg)
     config_for_each_port(cfg, port) {
         kni = kni_alloc(cfg, port);
         if (kni == NULL) {
+            kni_free(cfg);
             return -1;
         }
         port->kni = kni;
         snprintf(ring_name, sizeof(ring_name), "kr_%d", port->id);
         port->kni_mbuf_queue = rte_ring_create(ring_name, KNI_RING_SIZE, rte_socket_id(), RING_F_SC_DEQ);
         if (!port->kni_mbuf_queue) {
+            rte_kni_release(kni);
+            port->kni = NULL;
+            kni_free(cfg);
             return -2;
         }
     }


### PR DESCRIPTION
Root cause:
  kni_create iterates config_for_each_port, allocating a kni
  via kni_alloc and an rte_ring via rte_ring_create for each
  port. On any failure - kni_alloc returning NULL or
  rte_ring_create returning NULL - the function returns -1 or
  -2 immediately. The k kni handles and k rings already
  successfully created and stored in port->kni /
  port->kni_mbuf_queue are never released, leaking them
  permanently for the lifetime of the process.

Impact:
  Triggered when kni_alloc or rte_ring_create fails partway
  through a multi-port configuration, for example on resource
  exhaustion or a too-large ring size. On a 4-port config the
  first failure could leak up to 3 kni contexts and 3 rte_ring
  instances. kni_free is already defined in this file and is
  the symmetric cleanup path used by kni_stop, so omitting it
  here breaks the cleanup contract of the kni subsystem.

Style consistency:
  The fix mirrors the cleanup already done in kni_stop by
  calling kni_free on the early-return paths, and explicitly
  releases the current kni and clears port->kni before calling
  kni_free in the rte_ring_create failure path. No new
  functions or files added; kni_free's existing NULL guards
  make the new code path safe and idempotent.