### PR TITLE
fix: port_init_port_id silently uses wrong port_id when PCI lookup fails

### DIFF
--- a/src/port.c
+++ b/src/port.c
@@ -223,7 +223,7 @@ static int port_init_port_id(struct netif_port *port)
         pci = port->pci_list[i];
         if (rte_eth_dev_get_port_by_name(pci, &port_id) != 0) {
             printf("warning: cannot find port id by pci %s\n", pci);
-            port_id = (uint16_t)i;
+            return -1;
         }
 
         port->port_id_list[i] = port_id;


### PR DESCRIPTION
Root cause:
  port_init_port_id walks the per-port pci_list and calls
  rte_eth_dev_get_port_by_name for each entry. When the
  lookup fails, the function prints a warning and falls back
  to assigning the loop index i as the port_id, then continues
  the loop. The loop index is not a DPDK port_id; DPDK port_id
  is assigned by DPDK at startup based on the PCI allow list
  and any --vdev entries, and is not guaranteed to match the
  user-provided pci_list ordering.

Impact:
  When a pci_list entry does not match a DPDK-managed device,
  the function stores a fabricated port_id into
  port->port_id_list[i] and returns 0. Subsequent calls that
  use port_id_list[i], including rte_eth_dev_socket_id and the
  rx/tx init calls, then operate on whatever DPDK device
  happens to occupy that numeric id, which can be a different
  port or no port at all. The warning text makes the issue
  look benign, so a misconfigured dperf can keep running and
  emit corrupted traffic or hit unrelated device errors far
  from the root cause.

Style consistency:
  The fix removes the fabricated fallback by replacing
  port_id = (uint16_t)i with return -1, matching the fail-fast
  pattern used throughout the rest of port_init and across
  config_parse_* in config.c. No other call sites or files
  are affected.