### PR TITLE
fix: ctl g_stop is not volatile sig_atomic_t

### DIFF
--- a/src/ctl.c
+++ b/src/ctl.c
@@ -39,7 +39,7 @@
 #define CTL_CLIENT_LOG LOG_DIR"/dperf-ctl-client.log"
 #define CTL_SERVER_LOG LOG_DIR"/dperf-ctl-server.log"
 
-static bool g_stop = false;
+static volatile sig_atomic_t g_stop = 0;
 
 static FILE *ctl_log_open(struct config *cfg)
 {


### PR DESCRIPTION
Root cause:
  g_stop is a static bool that is read by the ctl main loop
  and written from ctl_signal_handler when SIGINT arrives. C11
  7.14.1.1 and POSIX signal-safety(7) require any object
  accessed from a signal handler to be of type
  volatile sig_atomic_t so that the read and the write are
  atomic and the compiler does not cache the read in a
  register. bool is not sig_atomic_t, so the existing code is
  undefined behavior at the language level and can be cached
  away at the optimizer level.

Impact:
  With optimization enabled, gcc or clang may hoist the read
  of g_stop inside the ctl main loop out of the loop body and
  keep the value in a register, so the write performed inside
  the signal handler is never observed. The result is that
  pressing Ctrl+C is silently ignored and the dperf process
  must be killed by an external SIGKILL.

Style consistency:
  The fix changes only the declaration; every read site uses
  if (g_stop) and every write site uses g_stop = true, which
  remain valid for sig_atomic_t initialized to 0. No new
  headers or files are required, since <signal.h> is already
  included in ctl.c.