### PR TITLE
fix: mbuf_data_ip_tot_len_add wraps uint16_t IP length to a small value

### DIFF
--- a/src/mbuf_cache.c
+++ b/src/mbuf_cache.c
@@ -78,11 +78,24 @@ static void mbuf_data_ip_tot_len_add(struct mbuf_data *mdata, uint16_t len)
 {
     struct iphdr *iph = mbuf_data_iphdr(mdata);
     struct ip6_hdr *ip6h = mbuf_data_ip6hdr(mdata);
+    uint32_t cur = 0;
+    uint32_t sum = 0;
 
     if (mdata->ipv6) {
-        ip6h->ip6_plen = htons((ntohs(ip6h->ip6_plen)) + len);
+        cur = ntohs(ip6h->ip6_plen);
     } else {
-        iph->tot_len = htons(ntohs(iph->tot_len) + len);
+        cur = ntohs(iph->tot_len);
+    }
+
+    sum = cur + len;
+    if (sum > UINT16_MAX) {
+        sum = UINT16_MAX;
+    }
+
+    if (mdata->ipv6) {
+        ip6h->ip6_plen = htons((uint16_t)sum);
+    } else {
+        iph->tot_len = htons((uint16_t)sum);
     }
 }
 


### PR DESCRIPTION
Root cause:
  mbuf_data_ip_tot_len_add adds len to the existing IPv4
  tot_len or IPv6 ip6_plen using htons(ntohs(field) + len).
  Both fields are uint16_t, and the inner addition can reach
  up to 65535 + 65535 = 131070. htons truncates the result
  back to uint16_t, so once the running length exceeds 65535
  the field wraps to len - 65536 and the mbuf is then sent
  with an IP length that is much smaller than the real
  packet size.

Impact:
  dperf builds the mbuf layer by layer: l2, l3, tcp or udp
  header, then one TCP option per call, then the payload.
  Each step calls mbuf_data_ip_tot_len_add. For a TCP packet
  close to the 16-bit limit, adding a single 4-byte TCP
  option, a TCP timestamp, or a SACK block pushes the running
  total past 65535 and the IP length is written as a small
  value. The receiver then sees a length field that is
  smaller than the real packet and either truncates the
  payload, fails the checksum, or drops the packet. The
  failure is silent on the dperf side.

Style consistency:
  The fix widens the running total to uint32_t, saturates
  the value to UINT16_MAX instead of wrapping, and only then
  writes the result back to the network-order field. The
  change is contained to mbuf_data_ip_tot_len_add; every
  call site keeps its existing mdata->l4_len or length
  argument and is unaffected.

```
## Reproducer

The accumulator is a uint16_t and the inner `ntohs(iph->tot_len) + len`
is a 17-bit value. To see the wrap without dperf, run the
following standalone program with any C compiler:

```c
#include <stdio.h> #include <stdint.h> #include <arpa/inet.h>

int main(void) { /* before fix: htons(ntohs(iph->tot_len) + len) / uint16_t cur = htons(65000); / tot_len after a large payload / uint16_t len = 1000; / another TCP option pushes over 65535 */ uint16_t wrapped = htons(ntohs(cur) + len); printf("before: 65000 + 1000 = %u (wrapped)\n", wrapped);


Plain Text

/* after fix: widen to uint32_t and saturate */
uint32_t sum = (uint32_t)ntohs(cur) + len;
if (sum > UINT16_MAX) sum = UINT16_MAX;
uint16_t safe = htons((uint16_t)sum);
printf("after:   65000 + 1000 = %u (saturated)\n", safe);
return 0;
```